### PR TITLE
Fixed Datepicker

### DIFF
--- a/resources/js/script_datetime.js
+++ b/resources/js/script_datetime.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
 
-  $(':date').datepicker();
-  $(':time').timepicker();
+  $('input[type="date"]').datepicker().attr('type','text');
+  $('input[type="time"]').timepicker().attr('type','text');
 
 });

--- a/src/inc.head.php
+++ b/src/inc.head.php
@@ -4,11 +4,11 @@
 
 <title>DMRC Service Portal</title>
 
-<link rel="stylesheet" href="../resources/css/bulma.css"> 
+<link rel="stylesheet" href="../resources/css/bulma.css">
 <link rel="stylesheet" href="../resources/css/font-awesome.min.css">
 <link rel="stylesheet" href="../resources/css/jquery-ui.min.css">
 <link rel="stylesheet" href="../resources/css/jquery-ui-timepicker-addon.css">
 
-<script src="../resources/js/jquery-3.2.1.min.js" defer></script>
+<script src="../resources/js/jquery-3.2.1.min.js"></script>
 <script src="../resources/js/jquery-ui.min.js" defer></script>
 <script src="../resources/js/jquery-ui-timepicker-addon.js" defer></script>


### PR DESCRIPTION
- inc.head.php: removed "defer" attribute to be sure, that jQuery is already loaded in order to prevent "jQuery is not defined"

- script_datetime.js: fixed jQuery selectors for date- and timepicker,
changed type of input to text after init date- and timepicker in order
to prevent native picker to be shown in newer browsers

closes #2 